### PR TITLE
Add missing HLS tags and improve RFC 8216 compliance for EXT-X-MAP

### DIFF
--- a/src/M3U8Parser/Attributes/Name/ByteRange.cs
+++ b/src/M3U8Parser/Attributes/Name/ByteRange.cs
@@ -1,0 +1,12 @@
+namespace M3U8Parser.Attributes.Name
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class ByteRange : StringAttribute
+    {
+        public ByteRange()
+            : base("BYTERANGE")
+        {
+        }
+    }
+}

--- a/src/M3U8Parser/Attributes/Name/Channels.cs
+++ b/src/M3U8Parser/Attributes/Name/Channels.cs
@@ -1,0 +1,12 @@
+namespace M3U8Parser.Attributes.Name
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class Channels : StringAttribute
+    {
+        public Channels()
+            : base("CHANNELS")
+        {
+        }
+    }
+}

--- a/src/M3U8Parser/Attributes/ValueType/BoolAttribute.cs
+++ b/src/M3U8Parser/Attributes/ValueType/BoolAttribute.cs
@@ -20,7 +20,7 @@ namespace M3U8Parser.Attributes.ValueType
         public override void Read(string content)
         {
             var pattern = $"(?={AttributeName})(.*?)(?=,|$)";
-            var match = Regex.Match(content.Trim(), pattern, RegexOptions.Multiline & RegexOptions.IgnoreCase);
+            var match = Regex.Match(content.Trim(), pattern, RegexOptions.Multiline | RegexOptions.IgnoreCase);
             if (!match.Success)
             {
                 return;

--- a/src/M3U8Parser/Attributes/ValueType/CustomAttribute.cs
+++ b/src/M3U8Parser/Attributes/ValueType/CustomAttribute.cs
@@ -22,7 +22,7 @@ namespace M3U8Parser.Attributes.ValueType
 
         public virtual void Read(string content)
         {
-            var match = Regex.Match(content.Trim(), $"[,|:](?={AttributeName})(.*?)(?=,|$)", RegexOptions.Multiline & RegexOptions.IgnoreCase);
+            var match = Regex.Match(content.Trim(), $"[,|:](?={AttributeName})(.*?)(?=,|$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
             var type = typeof(T);
 

--- a/src/M3U8Parser/Attributes/ValueType/DecimalAttribute.cs
+++ b/src/M3U8Parser/Attributes/ValueType/DecimalAttribute.cs
@@ -20,7 +20,7 @@ namespace M3U8Parser.Attributes.ValueType
         public override void Read(string content)
         {
             var pattern = $"(?={AttributeName})(.*?)(?=,|$)";
-            var match = Regex.Match(content.Trim(), pattern, RegexOptions.Multiline & RegexOptions.IgnoreCase);
+            var match = Regex.Match(content.Trim(), pattern, RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
             if (match.Success)
             {

--- a/src/M3U8Parser/Attributes/ValueType/StringAttribute.cs
+++ b/src/M3U8Parser/Attributes/ValueType/StringAttribute.cs
@@ -23,7 +23,7 @@ namespace M3U8Parser.Attributes.ValueType
 
         public override void Read(string content)
         {
-            var regexStr = Regex.Match(content.Trim(), $"(?<={AttributeName}=\")(.*?)(?=\",|\"$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+            var regexStr = Regex.Match(content.Trim(), $"(?<={AttributeName}=\")(.*?)(?=\",|\"\r?$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
             if (!regexStr.Success)
             {
                 return;

--- a/src/M3U8Parser/Attributes/ValueType/StringAttribute.cs
+++ b/src/M3U8Parser/Attributes/ValueType/StringAttribute.cs
@@ -23,7 +23,7 @@ namespace M3U8Parser.Attributes.ValueType
 
         public override void Read(string content)
         {
-            var regexStr = Regex.Match(content.Trim(), $"(?<={AttributeName}=\")(.*?)(?=\",|\"$)", RegexOptions.Multiline & RegexOptions.IgnoreCase);
+            var regexStr = Regex.Match(content.Trim(), $"(?<={AttributeName}=\")(.*?)(?=\",|\"$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
             if (!regexStr.Success)
             {
                 return;

--- a/src/M3U8Parser/MasterPlaylist.cs
+++ b/src/M3U8Parser/MasterPlaylist.cs
@@ -18,6 +18,8 @@
 
         public int HlsVersion { get; set; }
 
+        public IndependentSegments IndependentSegments { get; set; } = new ();
+
         public List<Media> Medias { get; set; } = new ();
 
         // ReSharper disable once InconsistentNaming
@@ -41,6 +43,7 @@
             List<IframeStreamInf> iFrameStreams = new ();
             List<StreamInf> streams = new ();
             var hlsVersion = DefaultHlsVersion;
+            IndependentSegments independentSegments = null;
 
             var l = Regex.Split(text, $"(?={Tag.EXTX})");
 
@@ -49,6 +52,10 @@
                 if (line.StartsWith(Tag.EXTXVERSION))
                 {
                     hlsVersion = new HlsVersion(line).Value;
+                }
+                else if (line.StartsWith(Tag.EXTXINDEPENDENTSEGMENTS))
+                {
+                    independentSegments = new IndependentSegments(line);
                 }
                 else if (line.StartsWith(Tag.EXTXMEDIA))
                 {
@@ -68,7 +75,8 @@
             {
                 Medias = medias,
                 Streams = streams,
-                IFrameStreams = iFrameStreams
+                IFrameStreams = iFrameStreams,
+                IndependentSegments = independentSegments
             };
         }
 
@@ -78,6 +86,11 @@
 
             strBuilder.AppendLine(Tag.EXTM3U);
             strBuilder.AppendLine($"{Tag.EXTXVERSION}:{HlsVersion}");
+
+            if (IndependentSegments != null && IndependentSegments.IsPresent)
+            {
+                strBuilder.AppendLine(IndependentSegments.ToString());
+            }
 
             strBuilder.AppendLine();
 

--- a/src/M3U8Parser/MediaPlaylist.cs
+++ b/src/M3U8Parser/MediaPlaylist.cs
@@ -1,5 +1,6 @@
-﻿namespace M3U8Parser
+namespace M3U8Parser
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
@@ -73,7 +74,7 @@
         public static MediaPlaylist LoadFromText(string text)
         {
             PlaylistType playlistType = null;
-            IndependentSegments IndependentSegments = null;
+            IndependentSegments independentSegments = null;
             List<MediaSegment> mediaSegments = new ();
             var hlsVersion = 4;
             var hasEndList = false;
@@ -81,124 +82,101 @@
             int? mediaSequence = null;
             bool? iFrameOnly = null;
 
-            var regex = new Regex($"(?={Tag.EXTX})(.*?)(?<=$)", RegexOptions.Multiline);
-            var matches = regex.Matches(text);
-
-            Map globalPlaylistMap = null;
-            foreach (Match match in matches)
-            {
-                var line = match.Value;
-                if (line.StartsWith(Tag.EXTXPLAYLISTTYPE))
-                {
-                    playlistType = new PlaylistTypeExt(line).Value;
-                }
-                else if (line.StartsWith(Tag.EXTXVERSION))
-                {
-                    hlsVersion = new HlsVersion(line).Value;
-                }
-                else if (line.StartsWith(Tag.EXTXINDEPENDENTSEGMENTS))
-                {
-                    IndependentSegments = new IndependentSegments(line);
-                }
-                else if (line.StartsWith(Tag.EXTXMAP))
-                {
-                    globalPlaylistMap = new Map(line);
-                }
-                else if (line.StartsWith(Tag.EXTXENDLIST))
-                {
-                    hasEndList = true;
-                }
-                else if (line.StartsWith(Tag.EXTXIFRAMESONLY))
-                {
-                    iFrameOnly = true;
-                }
-                else if (line.StartsWith(Tag.EXTXTARGETDURATION))
-                {
-                    targetDuration = new TargetDuration(line).Value;
-                }
-                else if (line.StartsWith(Tag.EXTXMEDIASEQUENCE))
-                {
-                    mediaSequence = new MediaSequence(line).Value;
-                }
-            }
-
-            var l = Regex.Split(text, $"(?={Tag.EXTXKEY}|#EXTINF:|{Tag.EXTXMAP}|{Tag.EXTXPROGRAMDATETIME})");
-            var segments = new List<Segment>();
-            MediaSegment mediaSegment = null;
+            Map currentMap = null;
             string currentProgramDateTime = null;
+            Key currentKey = null;
 
-            foreach (var line in l)
+            using (var reader = new StringReader(text))
             {
-                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#EXTM3U"))
+                List<Segment> currentSegments = new ();
+                string line;
+                while ((line = reader.ReadLine()) != null)
                 {
-                    continue;
-                }
-
-                if (line.StartsWith(Tag.EXTXMAP))
-                {
-                    globalPlaylistMap = new Map(line);
-                    continue;
-                }
-
-                if (line.StartsWith(Tag.EXTXPROGRAMDATETIME))
-                {
-                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTXPROGRAMDATETIME}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
-                    if (match.Success)
+                    line = line.Trim();
+                    if (string.IsNullOrEmpty(line) || line == Tag.EXTM3U)
                     {
-                        currentProgramDateTime = match.Groups[0].Value;
+                        continue;
                     }
-                    else
+
+                    if (line.StartsWith(Tag.EXTXVERSION))
                     {
-                        // Fallback: try to extract it from the line directly if the above fails
-                        var parts = line.Split(':');
-                        if (parts.Length > 1)
+                        hlsVersion = new HlsVersion(line).Value;
+                    }
+                    else if (line.StartsWith(Tag.EXTXPLAYLISTTYPE))
+                    {
+                        playlistType = new PlaylistTypeExt(line).Value;
+                    }
+                    else if (line.StartsWith(Tag.EXTXINDEPENDENTSEGMENTS))
+                    {
+                        independentSegments = new IndependentSegments(line);
+                    }
+                    else if (line.StartsWith(Tag.EXTXTARGETDURATION))
+                    {
+                        targetDuration = new TargetDuration(line).Value;
+                    }
+                    else if (line.StartsWith(Tag.EXTXMEDIASEQUENCE))
+                    {
+                        mediaSequence = new MediaSequence(line).Value;
+                    }
+                    else if (line.StartsWith(Tag.EXTXIFRAMESONLY))
+                    {
+                        iFrameOnly = true;
+                    }
+                    else if (line.StartsWith(Tag.EXTXENDLIST))
+                    {
+                        hasEndList = true;
+                    }
+                    else if (line.StartsWith(Tag.EXTXMAP))
+                    {
+                        currentMap = new Map(line);
+                    }
+                    else if (line.StartsWith(Tag.EXTXPROGRAMDATETIME))
+                    {
+                        var match = Regex.Match(line, $"(?<={Tag.EXTXPROGRAMDATETIME}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+                        currentProgramDateTime = match.Success ? match.Groups[0].Value : line.Split(':')[1].Trim();
+                    }
+                    else if (line.StartsWith(Tag.EXTXKEY))
+                    {
+                        if (currentSegments.Count > 0 || (currentKey != null && currentKey.Method != MethodType.None))
                         {
-                            currentProgramDateTime = string.Join(":", parts, 1, parts.Length - 1).Trim();
+                            mediaSegments.Add(new MediaSegment { Key = currentKey, Segments = currentSegments });
+                            currentSegments = new List<Segment>();
                         }
+                        currentKey = new Key(line);
                     }
-                    continue;
-                }
-
-                if (line.StartsWith(Tag.EXTXKEY))
-                {
-                    if (mediaSegment != null)
+                    else if (line.StartsWith(Tag.EXTINF))
                     {
-                        mediaSegment.Segments = segments;
-                        mediaSegments.Add(mediaSegment);
-                    }
+                        var segmentBlock = new StringBuilder();
+                        segmentBlock.AppendLine(line);
 
-                    mediaSegment = new MediaSegment(line);
-                    segments = new List<Segment>();
-                }
-                else if (line.StartsWith(Tag.EXTINF))
-                {
-                    mediaSegment ??= new MediaSegment();
+                        string nextLine;
+                        while ((nextLine = reader.ReadLine()) != null)
+                        {
+                            string trimmedNext = nextLine.Trim();
+                            if (string.IsNullOrEmpty(trimmedNext))
+                            {
+                                continue;
+                            }
 
-                    var segment = new Segment(line);
-                    if (segment.Map != null)
-                    {
-                        globalPlaylistMap = segment.Map;
-                    }
+                            segmentBlock.AppendLine(trimmedNext);
+                            if (!trimmedNext.StartsWith("#"))
+                            {
+                                break;
+                            }
+                        }
 
-                    if (segment.Map == null && globalPlaylistMap != null)
-                    {
-                        segment.Map = globalPlaylistMap;
-                    }
-
-                    if (segment.ProgramDateTime == null && currentProgramDateTime != null)
-                    {
+                        var segment = new Segment(segmentBlock.ToString());
+                        segment.Map = currentMap;
                         segment.ProgramDateTime = currentProgramDateTime;
-                        currentProgramDateTime = null;
+                        currentProgramDateTime = null; // Reset as per RFC 8216
+                        currentSegments.Add(segment);
                     }
-
-                    segments.Add(segment);
                 }
-            }
 
-            if (mediaSegment != null)
-            {
-                mediaSegment.Segments = segments;
-                mediaSegments.Add(mediaSegment);
+                if (currentSegments.Count > 0 || (currentKey != null && currentKey.Method != MethodType.None))
+                {
+                    mediaSegments.Add(new MediaSegment { Key = currentKey, Segments = currentSegments });
+                }
             }
 
             return new MediaPlaylist
@@ -210,7 +188,7 @@
                 TargetDuration = targetDuration,
                 MediaSequence = mediaSequence,
                 IFrameOnly = iFrameOnly,
-                IndependentSegments = IndependentSegments
+                IndependentSegments = independentSegments
             };
         }
 

--- a/src/M3U8Parser/MediaPlaylist.cs
+++ b/src/M3U8Parser/MediaPlaylist.cs
@@ -15,7 +15,38 @@
 
         public IndependentSegments IndependentSegments { get; set; } = new ();
 
-        public Map Map { get; set; } = new ();
+        public Map Map
+        {
+            get
+            {
+                if (MediaSegments.Count > 0)
+                {
+                    foreach (var mediaSegment in MediaSegments)
+                    {
+                        if (mediaSegment.Segments != null)
+                        {
+                            foreach (var segment in mediaSegment.Segments)
+                            {
+                                if (segment.Map != null)
+                                {
+                                    return segment.Map;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                return null;
+            }
+
+            set
+            {
+                if (MediaSegments.Count > 0 && MediaSegments[0].Segments.Count > 0)
+                {
+                    MediaSegments[0].Segments[0].Map = value;
+                }
+            }
+        }
 
         public int HlsVersion { get; set; }
 
@@ -43,7 +74,6 @@
         {
             PlaylistType playlistType = null;
             IndependentSegments IndependentSegments = null;
-            Map map = null;
             List<MediaSegment> mediaSegments = new ();
             var hlsVersion = 4;
             var hasEndList = false;
@@ -54,6 +84,7 @@
             var regex = new Regex($"(?={Tag.EXTX})(.*?)(?<=$)", RegexOptions.Multiline);
             var matches = regex.Matches(text);
 
+            Map globalPlaylistMap = null;
             foreach (Match match in matches)
             {
                 var line = match.Value;
@@ -71,7 +102,7 @@
                 }
                 else if (line.StartsWith(Tag.EXTXMAP))
                 {
-                    map = new Map(line);
+                    globalPlaylistMap = new Map(line);
                 }
                 else if (line.StartsWith(Tag.EXTXENDLIST))
                 {
@@ -91,11 +122,43 @@
                 }
             }
 
-            var l = Regex.Split(text, $"(?={Tag.EXTXKEY}|{Tag.EXTINF})");
+            var l = Regex.Split(text, $"(?={Tag.EXTXKEY}|#EXTINF:|{Tag.EXTXMAP}|{Tag.EXTXPROGRAMDATETIME})");
             var segments = new List<Segment>();
             MediaSegment mediaSegment = null;
+            string currentProgramDateTime = null;
+
             foreach (var line in l)
             {
+                if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#EXTM3U"))
+                {
+                    continue;
+                }
+
+                if (line.StartsWith(Tag.EXTXMAP))
+                {
+                    globalPlaylistMap = new Map(line);
+                    continue;
+                }
+
+                if (line.StartsWith(Tag.EXTXPROGRAMDATETIME))
+                {
+                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTXPROGRAMDATETIME}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+                    if (match.Success)
+                    {
+                        currentProgramDateTime = match.Groups[0].Value;
+                    }
+                    else
+                    {
+                        // Fallback: try to extract it from the line directly if the above fails
+                        var parts = line.Split(':');
+                        if (parts.Length > 1)
+                        {
+                            currentProgramDateTime = string.Join(":", parts, 1, parts.Length - 1).Trim();
+                        }
+                    }
+                    continue;
+                }
+
                 if (line.StartsWith(Tag.EXTXKEY))
                 {
                     if (mediaSegment != null)
@@ -105,18 +168,38 @@
                     }
 
                     mediaSegment = new MediaSegment(line);
+                    segments = new List<Segment>();
                 }
-
-                if (line.StartsWith(Tag.EXTINF))
+                else if (line.StartsWith(Tag.EXTINF))
                 {
                     mediaSegment ??= new MediaSegment();
 
-                    segments.Add(new Segment(line));
+                    var segment = new Segment(line);
+                    if (segment.Map != null)
+                    {
+                        globalPlaylistMap = segment.Map;
+                    }
+
+                    if (segment.Map == null && globalPlaylistMap != null)
+                    {
+                        segment.Map = globalPlaylistMap;
+                    }
+
+                    if (segment.ProgramDateTime == null && currentProgramDateTime != null)
+                    {
+                        segment.ProgramDateTime = currentProgramDateTime;
+                        currentProgramDateTime = null;
+                    }
+
+                    segments.Add(segment);
                 }
             }
 
-            mediaSegment.Segments = segments;
-            mediaSegments.Add(mediaSegment);
+            if (mediaSegment != null)
+            {
+                mediaSegment.Segments = segments;
+                mediaSegments.Add(mediaSegment);
+            }
 
             return new MediaPlaylist
             {
@@ -127,8 +210,7 @@
                 TargetDuration = targetDuration,
                 MediaSequence = mediaSequence,
                 IFrameOnly = iFrameOnly,
-                IndependentSegments = IndependentSegments,
-                Map = map
+                IndependentSegments = IndependentSegments
             };
         }
 
@@ -162,11 +244,6 @@
             if (IFrameOnly.HasValue && IFrameOnly.Value)
             {
                 strBuilder.AppendLine(Tag.EXTXIFRAMESONLY);
-            }
-
-            if (Map != null)
-            {
-                strBuilder.AppendLine(Map.ToString());
             }
 
             foreach (var segment in MediaSegments)

--- a/src/M3U8Parser/MediaSegment.cs
+++ b/src/M3U8Parser/MediaSegment.cs
@@ -22,7 +22,7 @@
                 {
                     Key = new Key(line);
                 }
-                else if (line.StartsWith(Tag.EXTINF))
+                else if (line.StartsWith(Tag.EXTINF) || line.StartsWith(Tag.EXTXMAP) || line.StartsWith(Tag.EXTXPROGRAMDATETIME))
                 {
                     var segment = new Segment(line);
                     Segments.Add(segment);

--- a/src/M3U8Parser/Tags/AbstractTagOneValue.cs
+++ b/src/M3U8Parser/Tags/AbstractTagOneValue.cs
@@ -35,7 +35,7 @@ namespace M3U8Parser.Tags
 
         protected void ReadValue(string str)
         {
-            var match = Regex.Match(str.Trim(), $"(?<={TagName}:)(.*?)(?=$)", RegexOptions.Multiline & RegexOptions.IgnoreCase);
+            var match = Regex.Match(str.Trim(), $"(?<={TagName}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
             var type = typeof(T);
 

--- a/src/M3U8Parser/Tags/MediaSegment/Map.cs
+++ b/src/M3U8Parser/Tags/MediaSegment/Map.cs
@@ -5,6 +5,7 @@ namespace M3U8Parser.Tags.MediaSegment
     public class Map : AbstractTag
     {
         private readonly Uri _uri = new ();
+        private readonly ByteRange _byteRange = new ();
 
         public Map()
         {
@@ -18,6 +19,11 @@ namespace M3U8Parser.Tags.MediaSegment
         public string Uri {
             get => _uri.Value;
             set => _uri.Value = value;
+        }
+
+        public string ByteRange {
+            get => _byteRange.Value;
+            set => _byteRange.Value = value;
         }
 
         protected override string TagName => Tag.EXTXMAP;

--- a/src/M3U8Parser/Tags/MediaSegment/Segment.cs
+++ b/src/M3U8Parser/Tags/MediaSegment/Segment.cs
@@ -19,7 +19,7 @@
             {
                 if (line.StartsWith(Tag.EXTINF))
                 {
-                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTINF}:)(.*?)(?=$)", RegexOptions.Multiline & RegexOptions.IgnoreCase);
+                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTINF}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
                     if (match.Success)
                     {
@@ -29,7 +29,7 @@
                 }
                 else if (line.StartsWith(Tag.EXTXBYTERANGE))
                 {
-                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTXBYTERANGE}:)(.*?)(?=$)", RegexOptions.Multiline & RegexOptions.IgnoreCase);
+                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTXBYTERANGE}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
 
                     if (match.Success)
                     {
@@ -41,6 +41,19 @@
                             ByteRangeStartSubRange = long.Parse(byterange[1]);
                         }
                     }
+                }
+                else if (line.StartsWith(Tag.EXTXPROGRAMDATETIME))
+                {
+                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTXPROGRAMDATETIME}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+
+                    if (match.Success)
+                    {
+                        ProgramDateTime = match.Groups[0].Value;
+                    }
+                }
+                else if (line.StartsWith(Tag.EXTXMAP))
+                {
+                    Map = new Map(line);
                 }
                 else if (!line.StartsWith("#EXT"))
                 {
@@ -59,9 +72,24 @@
 
         public long? ByteRangeStartSubRange { get; set; }
 
+        public string ProgramDateTime { get; set; }
+
+        public Map Map { get; set; }
+
         public override string ToString()
         {
             var strBuilder = new StringBuilder();
+
+            if (ProgramDateTime != null)
+            {
+                strBuilder.AppendLine($"{Tag.EXTXPROGRAMDATETIME}:{ProgramDateTime}");
+            }
+
+            if (Map != null)
+            {
+                strBuilder.AppendLine(Map.ToString());
+            }
+
             strBuilder.AppendLine($"{Tag.EXTINF}:{Duration.ToString(CultureInfo.InvariantCulture)},{Title}");
 
             if (ByteRangeLentgh != null)

--- a/src/M3U8Parser/Tags/MultivariantPlaylist/Media.cs
+++ b/src/M3U8Parser/Tags/MultivariantPlaylist/Media.cs
@@ -14,6 +14,7 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
         private readonly Type _mediaType = new ();
         private readonly Name _name = new ();
         private readonly Uri _uri = new ();
+        private readonly Channels _channels = new ();
 
         public Media()
         {
@@ -76,6 +77,12 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
         {
             get => _characteristics.Value;
             set => _characteristics.Value = value;
+        }
+
+        public string Channels
+        {
+            get => _channels.Value;
+            set => _channels.Value = value;
         }
 
         protected override string TagName => Tag.EXTXMEDIA;

--- a/tests/M3U8Parser.Tests/M3U8Parser.Tests.csproj
+++ b/tests/M3U8Parser.Tests/M3U8Parser.Tests.csproj
@@ -15,10 +15,14 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+          <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\src\M3U8Parser\M3U8Parser.csproj"/>
+        <ProjectReference Include="..\..\src\M3U8Parser\M3U8Parser.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR implements several missing HLS tags and improves compliance with RFC 8216:

1. **EXT-X-INDEPENDENT-SEGMENTS**: Now supported in `MasterPlaylist`.
2. **CHANNELS**: Added to `EXT-X-MEDIA` tag in `MasterPlaylist`.
3. **EXT-X-PROGRAM-DATE-TIME**: Now parsed and serialized at the segment level in `MediaPlaylist`.
4. **EXT-X-MAP**: 
    - Added `BYTERANGE` attribute support.
    - Updated the parser to handle it as a stateful tag that applies to following segments, as required by RFC 8216.

The `MediaPlaylist` parser was refactored to correctly associate metadata tags with segments and maintain state (like the current map) across segment blocks. Existing tests have been updated/verified to ensure no regressions in how global playlist properties (like the initial Map) are accessed.

---
*PR created automatically by Jules for task [7728551761853673487](https://jules.google.com/task/7728551761853673487) started by @xavierlaffargue*