### PR TITLE
Add support for HLS Bis tags and attributes

### DIFF
--- a/src/M3U8Parser/Attributes/ValueType/UnquotedStringAttribute.cs
+++ b/src/M3U8Parser/Attributes/ValueType/UnquotedStringAttribute.cs
@@ -1,0 +1,10 @@
+namespace M3U8Parser.Attributes.ValueType
+{
+    public class UnquotedStringAttribute : CustomAttribute<string>
+    {
+        public UnquotedStringAttribute(string attributeName)
+            : base(attributeName)
+        {
+        }
+    }
+}

--- a/src/M3U8Parser/MasterPlaylist.cs
+++ b/src/M3U8Parser/MasterPlaylist.cs
@@ -1,4 +1,4 @@
-﻿namespace M3U8Parser
+namespace M3U8Parser
 {
     using System.Collections.Generic;
     using System.IO;
@@ -19,6 +19,10 @@
         public int HlsVersion { get; set; }
 
         public IndependentSegments IndependentSegments { get; set; } = new ();
+
+        public ContentSteering ContentSteering { get; set; }
+
+        public List<Define> Defines { get; set; } = new ();
 
         public List<Media> Medias { get; set; } = new ();
 
@@ -44,6 +48,8 @@
             List<StreamInf> streams = new ();
             var hlsVersion = DefaultHlsVersion;
             IndependentSegments independentSegments = null;
+            ContentSteering contentSteering = null;
+            List<Define> defines = new ();
 
             var l = Regex.Split(text, $"(?={Tag.EXTX})");
 
@@ -69,6 +75,14 @@
                 {
                     streams.Add(new StreamInf(line));
                 }
+                else if (line.StartsWith(Tag.EXTXCONTENTSTEERING))
+                {
+                    contentSteering = new ContentSteering(line);
+                }
+                else if (line.StartsWith(Tag.EXTXDEFINE))
+                {
+                    defines.Add(new Define(line));
+                }
             }
 
             return new MasterPlaylist(hlsVersion)
@@ -76,7 +90,9 @@
                 Medias = medias,
                 Streams = streams,
                 IFrameStreams = iFrameStreams,
-                IndependentSegments = independentSegments
+                IndependentSegments = independentSegments,
+                ContentSteering = contentSteering,
+                Defines = defines
             };
         }
 
@@ -90,6 +106,19 @@
             if (IndependentSegments != null && IndependentSegments.IsPresent)
             {
                 strBuilder.AppendLine(IndependentSegments.ToString());
+            }
+
+            if (ContentSteering != null)
+            {
+                strBuilder.AppendLine(ContentSteering.ToString());
+            }
+
+            if (Defines is { Count: > 0 })
+            {
+                foreach (var define in Defines)
+                {
+                    strBuilder.AppendLine(define.ToString());
+                }
             }
 
             strBuilder.AppendLine();

--- a/src/M3U8Parser/MediaPlaylist.cs
+++ b/src/M3U8Parser/MediaPlaylist.cs
@@ -71,6 +71,8 @@ namespace M3U8Parser
 
         public List<Define> Defines { get; set; } = new ();
 
+        public List<DateRange> DateRanges { get; set; } = new ();
+
         public List<MediaSegment> MediaSegments { get; set; } = new ();
 
         public bool HasEndList { get; set; }
@@ -102,6 +104,7 @@ namespace M3U8Parser
             List<PreloadHint> preloadHints = new ();
             List<RenditionReport> renditionReports = new ();
             List<Define> defines = new ();
+            List<DateRange> dateRanges = new ();
 
             Map currentMap = null;
             string currentProgramDateTime = null;
@@ -193,6 +196,10 @@ namespace M3U8Parser
                     {
                         defines.Add(new Define(line));
                     }
+                    else if (line.StartsWith(Tag.EXTXDATERANGE))
+                    {
+                        dateRanges.Add(new DateRange(line));
+                    }
                     else if (line.StartsWith(Tag.EXTXGAP))
                     {
                         currentGap = true;
@@ -267,7 +274,8 @@ namespace M3U8Parser
                 PreloadHints = preloadHints,
                 RenditionReports = renditionReports,
                 Parts = currentParts,
-                Defines = defines
+                Defines = defines,
+                DateRanges = dateRanges
             };
         }
 
@@ -324,6 +332,14 @@ namespace M3U8Parser
             if (Skip != null)
             {
                 strBuilder.AppendLine(Skip.ToString());
+            }
+
+            if (DateRanges is { Count: > 0 })
+            {
+                foreach (var dateRange in DateRanges)
+                {
+                    strBuilder.AppendLine(dateRange.ToString());
+                }
             }
 
             foreach (var segment in MediaSegments)

--- a/src/M3U8Parser/MediaPlaylist.cs
+++ b/src/M3U8Parser/MediaPlaylist.cs
@@ -57,6 +57,20 @@ namespace M3U8Parser
 
         public int? MediaSequence { get; set; }
 
+        public ServerControl ServerControl { get; set; }
+
+        public Skip Skip { get; set; }
+
+        public PartInf PartInf { get; set; }
+
+        public List<PreloadHint> PreloadHints { get; set; } = new ();
+
+        public List<RenditionReport> RenditionReports { get; set; } = new ();
+
+        public List<Part> Parts { get; set; } = new ();
+
+        public List<Define> Defines { get; set; } = new ();
+
         public List<MediaSegment> MediaSegments { get; set; } = new ();
 
         public bool HasEndList { get; set; }
@@ -82,9 +96,19 @@ namespace M3U8Parser
             int? mediaSequence = null;
             bool? iFrameOnly = null;
 
+            ServerControl serverControl = null;
+            Skip skip = null;
+            PartInf partInf = null;
+            List<PreloadHint> preloadHints = new ();
+            List<RenditionReport> renditionReports = new ();
+            List<Define> defines = new ();
+
             Map currentMap = null;
             string currentProgramDateTime = null;
             Key currentKey = null;
+            bool currentGap = false;
+            int? currentBitrate = null;
+            List<Part> currentParts = new ();
 
             using (var reader = new StringReader(text))
             {
@@ -142,7 +166,48 @@ namespace M3U8Parser
                             mediaSegments.Add(new MediaSegment { Key = currentKey, Segments = currentSegments });
                             currentSegments = new List<Segment>();
                         }
+
                         currentKey = new Key(line);
+                    }
+                    else if (line.StartsWith(Tag.EXTXSERVERCONTROL))
+                    {
+                        serverControl = new ServerControl(line);
+                    }
+                    else if (line.StartsWith(Tag.EXTXSKIP))
+                    {
+                        skip = new Skip(line);
+                    }
+                    else if (line.StartsWith(Tag.EXTXPARTINF))
+                    {
+                        partInf = new PartInf(line);
+                    }
+                    else if (line.StartsWith(Tag.EXTXPRELOADHINT))
+                    {
+                        preloadHints.Add(new PreloadHint(line));
+                    }
+                    else if (line.StartsWith(Tag.EXTXRENDITIONREPORT))
+                    {
+                        renditionReports.Add(new RenditionReport(line));
+                    }
+                    else if (line.StartsWith(Tag.EXTXDEFINE))
+                    {
+                        defines.Add(new Define(line));
+                    }
+                    else if (line.StartsWith(Tag.EXTXGAP))
+                    {
+                        currentGap = true;
+                    }
+                    else if (line.StartsWith(Tag.EXTXBITRATE))
+                    {
+                        var match = Regex.Match(line, $"(?<={Tag.EXTXBITRATE}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+                        if (match.Success)
+                        {
+                            currentBitrate = int.Parse(match.Groups[0].Value);
+                        }
+                    }
+                    else if (line.StartsWith(Tag.EXTXPART))
+                    {
+                        currentParts.Add(new Part(line));
                     }
                     else if (line.StartsWith(Tag.EXTINF))
                     {
@@ -168,7 +233,14 @@ namespace M3U8Parser
                         var segment = new Segment(segmentBlock.ToString());
                         segment.Map = currentMap;
                         segment.ProgramDateTime = currentProgramDateTime;
+                        segment.Gap = currentGap;
+                        segment.Bitrate = currentBitrate;
+                        segment.Parts = currentParts;
+
                         currentProgramDateTime = null; // Reset as per RFC 8216
+                        currentGap = false; // Reset for next segment
+                        currentParts = new List<Part>(); // Reset for next segment
+
                         currentSegments.Add(segment);
                     }
                 }
@@ -188,7 +260,14 @@ namespace M3U8Parser
                 TargetDuration = targetDuration,
                 MediaSequence = mediaSequence,
                 IFrameOnly = iFrameOnly,
-                IndependentSegments = independentSegments
+                IndependentSegments = independentSegments,
+                ServerControl = serverControl,
+                Skip = skip,
+                PartInf = partInf,
+                PreloadHints = preloadHints,
+                RenditionReports = renditionReports,
+                Parts = currentParts,
+                Defines = defines
             };
         }
 
@@ -202,6 +281,24 @@ namespace M3U8Parser
             if (IndependentSegments != null && IndependentSegments.IsPresent)
             {
                 strBuilder.AppendLine(IndependentSegments.ToString());
+            }
+
+            if (Defines is { Count: > 0 })
+            {
+                foreach (var define in Defines)
+                {
+                    strBuilder.AppendLine(define.ToString());
+                }
+            }
+
+            if (ServerControl != null)
+            {
+                strBuilder.AppendLine(ServerControl.ToString());
+            }
+
+            if (PartInf != null)
+            {
+                strBuilder.AppendLine(PartInf.ToString());
             }
 
             if (TargetDuration != null)
@@ -224,10 +321,40 @@ namespace M3U8Parser
                 strBuilder.AppendLine(Tag.EXTXIFRAMESONLY);
             }
 
+            if (Skip != null)
+            {
+                strBuilder.AppendLine(Skip.ToString());
+            }
+
             foreach (var segment in MediaSegments)
             {
                 strBuilder.AppendLine();
                 strBuilder.Append(segment);
+            }
+
+            if (Parts is { Count: > 0 })
+            {
+                strBuilder.AppendLine();
+                foreach (var part in Parts)
+                {
+                    strBuilder.AppendLine(part.ToString());
+                }
+            }
+
+            if (PreloadHints is { Count: > 0 })
+            {
+                foreach (var hint in PreloadHints)
+                {
+                    strBuilder.AppendLine(hint.ToString());
+                }
+            }
+
+            if (RenditionReports is { Count: > 0 })
+            {
+                foreach (var report in RenditionReports)
+                {
+                    strBuilder.AppendLine(report.ToString());
+                }
             }
 
             if (HasEndList)

--- a/src/M3U8Parser/Tag.cs
+++ b/src/M3U8Parser/Tag.cs
@@ -25,6 +25,7 @@ namespace M3U8Parser
         public static readonly string EXTXCUEIN = $"{EXTX}-CUE-IN";
         public static readonly string EXTXSTART = $"{EXTX}-START";
         public static readonly string EXTXENDLIST = $"{EXTX}-ENDLIST";
+        public static readonly string EXTXDATERANGE = $"{EXTX}-DATERANGE";
         public static readonly string EXTXGAP = $"{EXTX}-GAP";
         public static readonly string EXTXBITRATE = $"{EXTX}-BITRATE";
         public static readonly string EXTXSERVERCONTROL = $"{EXTX}-SERVER-CONTROL";

--- a/src/M3U8Parser/Tag.cs
+++ b/src/M3U8Parser/Tag.cs
@@ -25,5 +25,15 @@ namespace M3U8Parser
         public static readonly string EXTXCUEIN = $"{EXTX}-CUE-IN";
         public static readonly string EXTXSTART = $"{EXTX}-START";
         public static readonly string EXTXENDLIST = $"{EXTX}-ENDLIST";
+        public static readonly string EXTXGAP = $"{EXTX}-GAP";
+        public static readonly string EXTXBITRATE = $"{EXTX}-BITRATE";
+        public static readonly string EXTXSERVERCONTROL = $"{EXTX}-SERVER-CONTROL";
+        public static readonly string EXTXSKIP = $"{EXTX}-SKIP";
+        public static readonly string EXTXPARTINF = $"{EXTX}-PART-INF";
+        public static readonly string EXTXPART = $"{EXTX}-PART";
+        public static readonly string EXTXPRELOADHINT = $"{EXTX}-PRELOAD-HINT";
+        public static readonly string EXTXRENDITIONREPORT = $"{EXTX}-RENDITION-REPORT";
+        public static readonly string EXTXCONTENTSTEERING = $"{EXTX}-CONTENT-STEERING";
+        public static readonly string EXTXDEFINE = $"{EXTX}-DEFINE";
     }
 }

--- a/src/M3U8Parser/Tags/Basic/Define.cs
+++ b/src/M3U8Parser/Tags/Basic/Define.cs
@@ -1,0 +1,47 @@
+namespace M3U8Parser.Tags.Basic
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class Define : AbstractTag
+    {
+        private readonly StringAttribute _name = new ("NAME");
+        private readonly StringAttribute _value = new ("VALUE");
+        private readonly StringAttribute _import = new ("IMPORT");
+        private readonly StringAttribute _queryParam = new ("QUERYPARAM");
+
+        public Define()
+        {
+        }
+
+        public Define(string str)
+            : base(str)
+        {
+        }
+
+        public string Name
+        {
+            get => _name.Value;
+            set => _name.Value = value;
+        }
+
+        public string Value
+        {
+            get => _value.Value;
+            set => _value.Value = value;
+        }
+
+        public string Import
+        {
+            get => _import.Value;
+            set => _import.Value = value;
+        }
+
+        public string QueryParam
+        {
+            get => _queryParam.Value;
+            set => _queryParam.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXDEFINE;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaPlaylist/DateRange.cs
+++ b/src/M3U8Parser/Tags/MediaPlaylist/DateRange.cs
@@ -1,0 +1,207 @@
+namespace M3U8Parser.Tags.MediaPlaylist
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class DateRange : AbstractTag
+    {
+        private readonly StringAttribute _id = new ("ID");
+        private readonly StringAttribute _class = new ("CLASS");
+        private readonly StringAttribute _startDate = new ("START-DATE");
+        private readonly StringAttribute _cue = new ("CUE");
+        private readonly StringAttribute _endDate = new ("END-DATE");
+        private readonly DecimalAttribute _duration = new ("DURATION");
+        private readonly DecimalAttribute _plannedDuration = new ("PLANNED-DURATION");
+        private readonly UnquotedStringAttribute _scte35Cmd = new ("SCTE35-CMD");
+        private readonly UnquotedStringAttribute _scte35Out = new ("SCTE35-OUT");
+        private readonly UnquotedStringAttribute _scte35In = new ("SCTE35-IN");
+        private readonly UnquotedStringAttribute _endOnNext = new ("END-ON-NEXT");
+
+        // HLS Interstitials Attributes (Appendix D.2)
+        private readonly StringAttribute _xAssetUri = new ("X-ASSET-URI");
+        private readonly StringAttribute _xAssetList = new ("X-ASSET-LIST");
+        private readonly DecimalAttribute _xResumeOffset = new ("X-RESUME-OFFSET");
+        private readonly DecimalAttribute _xPlayoutLimit = new ("X-PLAYOUT-LIMIT");
+        private readonly StringAttribute _xSnap = new ("X-SNAP");
+        private readonly StringAttribute _xRestrict = new ("X-RESTRICT");
+        private readonly StringAttribute _xContentMayVary = new ("X-CONTENT-MAY-VARY");
+        private readonly StringAttribute _xTimelineOccupies = new ("X-TIMELINE-OCCUPIES");
+        private readonly StringAttribute _xTimelineStyle = new ("X-TIMELINE-STYLE");
+
+        // HLS Skip Button Control Attributes (Appendix D.3)
+        private readonly IntegerAttribute _xSkipControlOffset = new ("X-SKIP-CONTROL-OFFSET");
+        private readonly IntegerAttribute _xSkipControlDuration = new ("X-SKIP-CONTROL-DURATION");
+        private readonly StringAttribute _xSkipControlLabelId = new ("X-SKIP-CONTROL-LABEL-ID");
+
+        // HLS Date Range Preloading Attributes (Appendix F)
+        private readonly StringAttribute _xUri = new ("X-URI");
+        private readonly StringAttribute _xTargetId = new ("X-TARGET-ID");
+        private readonly StringAttribute _xTargetClass = new ("X-TARGET-CLASS");
+
+        public DateRange()
+        {
+        }
+
+        public DateRange(string str)
+            : base(str)
+        {
+        }
+
+        public string Id
+        {
+            get => _id.Value;
+            set => _id.Value = value;
+        }
+
+        public string Class
+        {
+            get => _class.Value;
+            set => _class.Value = value;
+        }
+
+        public string StartDate
+        {
+            get => _startDate.Value;
+            set => _startDate.Value = value;
+        }
+
+        public string Cue
+        {
+            get => _cue.Value;
+            set => _cue.Value = value;
+        }
+
+        public string EndDate
+        {
+            get => _endDate.Value;
+            set => _endDate.Value = value;
+        }
+
+        public decimal? Duration
+        {
+            get => _duration.Value;
+            set => _duration.Value = value;
+        }
+
+        public decimal? PlannedDuration
+        {
+            get => _plannedDuration.Value;
+            set => _plannedDuration.Value = value;
+        }
+
+        public string Scte35Cmd
+        {
+            get => _scte35Cmd.Value;
+            set => _scte35Cmd.Value = value;
+        }
+
+        public string Scte35Out
+        {
+            get => _scte35Out.Value;
+            set => _scte35Out.Value = value;
+        }
+
+        public string Scte35In
+        {
+            get => _scte35In.Value;
+            set => _scte35In.Value = value;
+        }
+
+        public string EndOnNext
+        {
+            get => _endOnNext.Value;
+            set => _endOnNext.Value = value;
+        }
+
+        public string XAssetUri
+        {
+            get => _xAssetUri.Value;
+            set => _xAssetUri.Value = value;
+        }
+
+        public string XAssetList
+        {
+            get => _xAssetList.Value;
+            set => _xAssetList.Value = value;
+        }
+
+        public decimal? XResumeOffset
+        {
+            get => _xResumeOffset.Value;
+            set => _xResumeOffset.Value = value;
+        }
+
+        public decimal? XPlayoutLimit
+        {
+            get => _xPlayoutLimit.Value;
+            set => _xPlayoutLimit.Value = value;
+        }
+
+        public string XSnap
+        {
+            get => _xSnap.Value;
+            set => _xSnap.Value = value;
+        }
+
+        public string XRestrict
+        {
+            get => _xRestrict.Value;
+            set => _xRestrict.Value = value;
+        }
+
+        public string XContentMayVary
+        {
+            get => _xContentMayVary.Value;
+            set => _xContentMayVary.Value = value;
+        }
+
+        public string XTimelineOccupies
+        {
+            get => _xTimelineOccupies.Value;
+            set => _xTimelineOccupies.Value = value;
+        }
+
+        public string XTimelineStyle
+        {
+            get => _xTimelineStyle.Value;
+            set => _xTimelineStyle.Value = value;
+        }
+
+        public int? XSkipControlOffset
+        {
+            get => _xSkipControlOffset.Value;
+            set => _xSkipControlOffset.Value = value;
+        }
+
+        public int? XSkipControlDuration
+        {
+            get => _xSkipControlDuration.Value;
+            set => _xSkipControlDuration.Value = value;
+        }
+
+        public string XSkipControlLabelId
+        {
+            get => _xSkipControlLabelId.Value;
+            set => _xSkipControlLabelId.Value = value;
+        }
+
+        public string XUri
+        {
+            get => _xUri.Value;
+            set => _xUri.Value = value;
+        }
+
+        public string XTargetId
+        {
+            get => _xTargetId.Value;
+            set => _xTargetId.Value = value;
+        }
+
+        public string XTargetClass
+        {
+            get => _xTargetClass.Value;
+            set => _xTargetClass.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXDATERANGE;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaPlaylist/PartInf.cs
+++ b/src/M3U8Parser/Tags/MediaPlaylist/PartInf.cs
@@ -1,0 +1,26 @@
+namespace M3U8Parser.Tags.MediaPlaylist
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class PartInf : AbstractTag
+    {
+        private readonly DecimalAttribute _partTarget = new ("PART-TARGET");
+
+        public PartInf()
+        {
+        }
+
+        public PartInf(string str)
+            : base(str)
+        {
+        }
+
+        public decimal? PartTarget
+        {
+            get => _partTarget.Value;
+            set => _partTarget.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXPARTINF;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaPlaylist/PreloadHint.cs
+++ b/src/M3U8Parser/Tags/MediaPlaylist/PreloadHint.cs
@@ -1,0 +1,47 @@
+namespace M3U8Parser.Tags.MediaPlaylist
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class PreloadHint : AbstractTag
+    {
+        private readonly UnquotedStringAttribute _type = new ("TYPE");
+        private readonly StringAttribute _uri = new ("URI");
+        private readonly IntegerAttribute _byterangeStart = new ("BYTERANGE-START");
+        private readonly IntegerAttribute _byterangeLength = new ("BYTERANGE-LENGTH");
+
+        public PreloadHint()
+        {
+        }
+
+        public PreloadHint(string str)
+            : base(str)
+        {
+        }
+
+        public string Type
+        {
+            get => _type.Value;
+            set => _type.Value = value;
+        }
+
+        public string Uri
+        {
+            get => _uri.Value;
+            set => _uri.Value = value;
+        }
+
+        public int? ByteRangeStart
+        {
+            get => _byterangeStart.Value;
+            set => _byterangeStart.Value = value;
+        }
+
+        public int? ByteRangeLength
+        {
+            get => _byterangeLength.Value;
+            set => _byterangeLength.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXPRELOADHINT;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaPlaylist/RenditionReport.cs
+++ b/src/M3U8Parser/Tags/MediaPlaylist/RenditionReport.cs
@@ -1,0 +1,40 @@
+namespace M3U8Parser.Tags.MediaPlaylist
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class RenditionReport : AbstractTag
+    {
+        private readonly StringAttribute _uri = new ("URI");
+        private readonly IntegerAttribute _lastMsn = new ("LAST-MSN");
+        private readonly IntegerAttribute _lastPart = new ("LAST-PART");
+
+        public RenditionReport()
+        {
+        }
+
+        public RenditionReport(string str)
+            : base(str)
+        {
+        }
+
+        public string Uri
+        {
+            get => _uri.Value;
+            set => _uri.Value = value;
+        }
+
+        public int? LastMsn
+        {
+            get => _lastMsn.Value;
+            set => _lastMsn.Value = value;
+        }
+
+        public int? LastPart
+        {
+            get => _lastPart.Value;
+            set => _lastPart.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXRENDITIONREPORT;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaPlaylist/ServerControl.cs
+++ b/src/M3U8Parser/Tags/MediaPlaylist/ServerControl.cs
@@ -1,0 +1,54 @@
+namespace M3U8Parser.Tags.MediaPlaylist
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class ServerControl : AbstractTag
+    {
+        private readonly DecimalAttribute _canSkipUntil = new ("CAN-SKIP-UNTIL");
+        private readonly BoolAttribute _canSkipDateRanges = new ("CAN-SKIP-DATERANGES");
+        private readonly DecimalAttribute _holdBack = new ("HOLD-BACK");
+        private readonly DecimalAttribute _partHoldBack = new ("PART-HOLD-BACK");
+        private readonly BoolAttribute _canBlockReload = new ("CAN-BLOCK-RELOAD");
+
+        public ServerControl()
+        {
+        }
+
+        public ServerControl(string str)
+            : base(str)
+        {
+        }
+
+        public decimal? CanSkipUntil
+        {
+            get => _canSkipUntil.Value;
+            set => _canSkipUntil.Value = value;
+        }
+
+        public bool CanSkipDateRanges
+        {
+            get => _canSkipDateRanges.Value;
+            set => _canSkipDateRanges.Value = value;
+        }
+
+        public decimal? HoldBack
+        {
+            get => _holdBack.Value;
+            set => _holdBack.Value = value;
+        }
+
+        public decimal? PartHoldBack
+        {
+            get => _partHoldBack.Value;
+            set => _partHoldBack.Value = value;
+        }
+
+        public bool CanBlockReload
+        {
+            get => _canBlockReload.Value;
+            set => _canBlockReload.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXSERVERCONTROL;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaPlaylist/Skip.cs
+++ b/src/M3U8Parser/Tags/MediaPlaylist/Skip.cs
@@ -1,0 +1,33 @@
+namespace M3U8Parser.Tags.MediaPlaylist
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class Skip : AbstractTag
+    {
+        private readonly IntegerAttribute _skippedSegments = new ("SKIPPED-SEGMENTS");
+        private readonly StringAttribute _recentlyRemovedDateRanges = new ("RECENTLY-REMOVED-DATERANGES");
+
+        public Skip()
+        {
+        }
+
+        public Skip(string str)
+            : base(str)
+        {
+        }
+
+        public int? SkippedSegments
+        {
+            get => _skippedSegments.Value;
+            set => _skippedSegments.Value = value;
+        }
+
+        public string RecentlyRemovedDateRanges
+        {
+            get => _recentlyRemovedDateRanges.Value;
+            set => _recentlyRemovedDateRanges.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXSKIP;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaSegment/Part.cs
+++ b/src/M3U8Parser/Tags/MediaSegment/Part.cs
@@ -1,0 +1,54 @@
+namespace M3U8Parser.Tags.MediaSegment
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class Part : AbstractTag
+    {
+        private readonly StringAttribute _uri = new ("URI");
+        private readonly DecimalAttribute _duration = new ("DURATION");
+        private readonly BoolAttribute _independent = new ("INDEPENDENT");
+        private readonly StringAttribute _byterange = new ("BYTERANGE");
+        private readonly BoolAttribute _gap = new ("GAP");
+
+        public Part()
+        {
+        }
+
+        public Part(string str)
+            : base(str)
+        {
+        }
+
+        public string Uri
+        {
+            get => _uri.Value;
+            set => _uri.Value = value;
+        }
+
+        public decimal? Duration
+        {
+            get => _duration.Value;
+            set => _duration.Value = value;
+        }
+
+        public bool Independent
+        {
+            get => _independent.Value;
+            set => _independent.Value = value;
+        }
+
+        public string ByteRange
+        {
+            get => _byterange.Value;
+            set => _byterange.Value = value;
+        }
+
+        public bool Gap
+        {
+            get => _gap.Value;
+            set => _gap.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXPART;
+    }
+}

--- a/src/M3U8Parser/Tags/MediaSegment/Segment.cs
+++ b/src/M3U8Parser/Tags/MediaSegment/Segment.cs
@@ -1,5 +1,6 @@
-﻿namespace M3U8Parser.Tags.MediaSegment
+namespace M3U8Parser.Tags.MediaSegment
 {
+    using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
     using System.Text;
@@ -55,6 +56,22 @@
                 {
                     Map = new Map(line);
                 }
+                else if (line.StartsWith(Tag.EXTXGAP))
+                {
+                    Gap = true;
+                }
+                else if (line.StartsWith(Tag.EXTXBITRATE))
+                {
+                    var match = Regex.Match(line.Trim(), $"(?<={Tag.EXTXBITRATE}:)(.*?)(?=$)", RegexOptions.Multiline | RegexOptions.IgnoreCase);
+                    if (match.Success)
+                    {
+                        Bitrate = int.Parse(match.Groups[0].Value);
+                    }
+                }
+                else if (line.StartsWith(Tag.EXTXPART))
+                {
+                    Parts.Add(new Part(line));
+                }
                 else if (!line.StartsWith("#EXT"))
                 {
                     Uri = line;
@@ -76,6 +93,12 @@
 
         public Map Map { get; set; }
 
+        public bool Gap { get; set; }
+
+        public int? Bitrate { get; set; }
+
+        public List<Part> Parts { get; set; } = new ();
+
         public override string ToString()
         {
             var strBuilder = new StringBuilder();
@@ -88,6 +111,24 @@
             if (Map != null)
             {
                 strBuilder.AppendLine(Map.ToString());
+            }
+
+            if (Parts is { Count: > 0 })
+            {
+                foreach (var part in Parts)
+                {
+                    strBuilder.AppendLine(part.ToString());
+                }
+            }
+
+            if (Gap)
+            {
+                strBuilder.AppendLine(Tag.EXTXGAP);
+            }
+
+            if (Bitrate != null)
+            {
+                strBuilder.AppendLine($"{Tag.EXTXBITRATE}:{Bitrate}");
             }
 
             strBuilder.AppendLine($"{Tag.EXTINF}:{Duration.ToString(CultureInfo.InvariantCulture)},{Title}");

--- a/src/M3U8Parser/Tags/MultivariantPlaylist/ContentSteering.cs
+++ b/src/M3U8Parser/Tags/MultivariantPlaylist/ContentSteering.cs
@@ -1,0 +1,33 @@
+namespace M3U8Parser.Tags.MultivariantPlaylist
+{
+    using M3U8Parser.Attributes.ValueType;
+
+    public class ContentSteering : AbstractTag
+    {
+        private readonly StringAttribute _serverUri = new ("SERVER-URI");
+        private readonly StringAttribute _pathwayId = new ("PATHWAY-ID");
+
+        public ContentSteering()
+        {
+        }
+
+        public ContentSteering(string str)
+            : base(str)
+        {
+        }
+
+        public string ServerUri
+        {
+            get => _serverUri.Value;
+            set => _serverUri.Value = value;
+        }
+
+        public string PathwayId
+        {
+            get => _pathwayId.Value;
+            set => _pathwayId.Value = value;
+        }
+
+        protected override string TagName => Tag.EXTXCONTENTSTEERING;
+    }
+}

--- a/src/M3U8Parser/Tags/MultivariantPlaylist/IframeStreamInf.cs
+++ b/src/M3U8Parser/Tags/MultivariantPlaylist/IframeStreamInf.cs
@@ -14,6 +14,14 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
         private readonly Video _video = new ();
         private readonly VideoRange _videoRange = new ();
 
+        // New attributes introduced in RFC 8216 Bis / draft 22
+        private readonly DecimalAttribute _score = new ("SCORE");
+        private readonly StringAttribute _supplementalCodecs = new ("SUPPLEMENTAL-CODECS");
+        private readonly StringAttribute _allowedCpc = new ("ALLOWED-CPC");
+        private readonly StringAttribute _stableVariantId = new ("STABLE-VARIANT-ID");
+        private readonly StringAttribute _pathwayId = new ("PATHWAY-ID");
+        private readonly StringAttribute _reqVideoLayout = new ("REQ-VIDEO-LAYOUT");
+
         public IframeStreamInf()
         {
         }
@@ -69,6 +77,42 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
         {
             get => _uri.Value;
             set => _uri.Value = value;
+        }
+
+        public decimal? Score
+        {
+            get => _score.Value;
+            set => _score.Value = value;
+        }
+
+        public string SupplementalCodecs
+        {
+            get => _supplementalCodecs.Value;
+            set => _supplementalCodecs.Value = value;
+        }
+
+        public string AllowedCpc
+        {
+            get => _allowedCpc.Value;
+            set => _allowedCpc.Value = value;
+        }
+
+        public string StableVariantId
+        {
+            get => _stableVariantId.Value;
+            set => _stableVariantId.Value = value;
+        }
+
+        public string PathwayId
+        {
+            get => _pathwayId.Value;
+            set => _pathwayId.Value = value;
+        }
+
+        public string ReqVideoLayout
+        {
+            get => _reqVideoLayout.Value;
+            set => _reqVideoLayout.Value = value;
         }
 
         protected override string TagName => Tag.EXTXIFRAMESTREAMINF;

--- a/src/M3U8Parser/Tags/MultivariantPlaylist/Media.cs
+++ b/src/M3U8Parser/Tags/MultivariantPlaylist/Media.cs
@@ -16,6 +16,11 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
         private readonly Uri _uri = new ();
         private readonly Channels _channels = new ();
 
+        // New attributes introduced in RFC 8216 Bis / draft 22
+        private readonly StringAttribute _stableRenditionId = new ("STABLE-RENDITION-ID");
+        private readonly IntegerAttribute _bitDepth = new ("BIT-DEPTH");
+        private readonly IntegerAttribute _sampleRate = new ("SAMPLE-RATE");
+
         public Media()
         {
         }
@@ -83,6 +88,24 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
         {
             get => _channels.Value;
             set => _channels.Value = value;
+        }
+
+        public string StableRenditionId
+        {
+            get => _stableRenditionId.Value;
+            set => _stableRenditionId.Value = value;
+        }
+
+        public int? BitDepth
+        {
+            get => _bitDepth.Value;
+            set => _bitDepth.Value = value;
+        }
+
+        public int? SampleRate
+        {
+            get => _sampleRate.Value;
+            set => _sampleRate.Value = value;
         }
 
         protected override string TagName => Tag.EXTXMEDIA;

--- a/src/M3U8Parser/Tags/MultivariantPlaylist/StreamInf.cs
+++ b/src/M3U8Parser/Tags/MultivariantPlaylist/StreamInf.cs
@@ -21,6 +21,14 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
         private readonly Video _video = new ();
         private readonly VideoRange _videoRange = new ();
 
+        // New attributes introduced in RFC 8216 Bis / draft 22
+        private readonly DecimalAttribute _score = new ("SCORE");
+        private readonly StringAttribute _supplementalCodecs = new ("SUPPLEMENTAL-CODECS");
+        private readonly StringAttribute _allowedCpc = new ("ALLOWED-CPC");
+        private readonly StringAttribute _stableVariantId = new ("STABLE-VARIANT-ID");
+        private readonly StringAttribute _pathwayId = new ("PATHWAY-ID");
+        private readonly StringAttribute _reqVideoLayout = new ("REQ-VIDEO-LAYOUT");
+
         public StreamInf()
         {
         }
@@ -42,6 +50,14 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
             _subtitles.Read(lineWithAttribute);
             _closedCaptions.Read(lineWithAttribute);
             _resolutionAttribute.Read(lineWithAttribute);
+
+            _score.Read(lineWithAttribute);
+            _supplementalCodecs.Read(lineWithAttribute);
+            _allowedCpc.Read(lineWithAttribute);
+            _stableVariantId.Read(lineWithAttribute);
+            _pathwayId.Read(lineWithAttribute);
+            _reqVideoLayout.Read(lineWithAttribute);
+
             Uri = lineWithUri;
         }
 
@@ -117,6 +133,42 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
             set => _resolutionAttribute.Value = value;
         }
 
+        public decimal? Score
+        {
+            get => _score.Value;
+            set => _score.Value = value;
+        }
+
+        public string SupplementalCodecs
+        {
+            get => _supplementalCodecs.Value;
+            set => _supplementalCodecs.Value = value;
+        }
+
+        public string AllowedCpc
+        {
+            get => _allowedCpc.Value;
+            set => _allowedCpc.Value = value;
+        }
+
+        public string StableVariantId
+        {
+            get => _stableVariantId.Value;
+            set => _stableVariantId.Value = value;
+        }
+
+        public string PathwayId
+        {
+            get => _pathwayId.Value;
+            set => _pathwayId.Value = value;
+        }
+
+        public string ReqVideoLayout
+        {
+            get => _reqVideoLayout.Value;
+            set => _reqVideoLayout.Value = value;
+        }
+
         public override string ToString()
         {
             var strBuilder = new StringBuilder();
@@ -133,6 +185,13 @@ namespace M3U8Parser.Tags.MultivariantPlaylist
             strBuilder.AppendWithSeparator(_video.ToString(), ",");
             strBuilder.AppendWithSeparator(_audio.ToString(), ",");
             strBuilder.AppendWithSeparator(_subtitles.ToString(), ",");
+
+            strBuilder.AppendWithSeparator(_score.ToString(), ",");
+            strBuilder.AppendWithSeparator(_supplementalCodecs.ToString(), ",");
+            strBuilder.AppendWithSeparator(_allowedCpc.ToString(), ",");
+            strBuilder.AppendWithSeparator(_stableVariantId.ToString(), ",");
+            strBuilder.AppendWithSeparator(_pathwayId.ToString(), ",");
+            strBuilder.AppendWithSeparator(_reqVideoLayout.ToString(), ",");
 
             return strBuilder.ToString().RemoveLastCharacter() + "\r\n" + Uri;
         }

--- a/tests/M3U8Parser.Tests/M3U8Parser.Tests.csproj
+++ b/tests/M3U8Parser.Tests/M3U8Parser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/M3U8Parser.Tests/M3U8Parser.Tests.csproj
+++ b/tests/M3U8Parser.Tests/M3U8Parser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/tests/M3U8Parser.Tests/NewTagsAndAttributesTests.cs
+++ b/tests/M3U8Parser.Tests/NewTagsAndAttributesTests.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using M3U8Parser.Attributes.ValueType;
+using M3U8Parser.Tags.Basic;
+using M3U8Parser.Tags.MediaPlaylist;
+using M3U8Parser.Tags.MediaSegment;
+using M3U8Parser.Tags.MultivariantPlaylist;
+using Xunit;
+
+namespace M3U8Parser.Tests
+{
+    public class NewTagsAndAttributesTests
+    {
+        [Fact]
+        public void TestMasterPlaylistWithNewTagsAndAttributes()
+        {
+            var manifestText = @"#EXTM3U
+#EXT-X-VERSION:13
+#EXT-X-CONTENT-STEERING:SERVER-URI=""https://example.com/steering"",PATHWAY-ID=""CDN-A""
+#EXT-X-DEFINE:NAME=""VAR1"",VALUE=""VAL1""
+#EXT-X-DEFINE:IMPORT=""VAR2""
+
+#EXT-X-MEDIA:TYPE=AUDIO,GROUP-ID=""audio"",NAME=""English"",DEFAULT=YES,AUTOSELECT=YES,STABLE-RENDITION-ID=""Audio-37262"",BIT-DEPTH=24,SAMPLE-RATE=48000
+
+#EXT-X-STREAM-INF:BANDWIDTH=1280000,SCORE=9.5,SUPPLEMENTAL-CODECS=""dvh1.08.07/db4h"",ALLOWED-CPC=""com.example:HW"",STABLE-VARIANT-ID=""Video-128"",PATHWAY-ID=""CDN-A"",REQ-VIDEO-LAYOUT=""CH-STEREO,CH-MONO""
+128/video.m3u8";
+
+            var masterPlaylist = MasterPlaylist.LoadFromText(manifestText);
+
+            // Assertions for version
+            Assert.Equal(13, masterPlaylist.HlsVersion);
+
+            // Assertions for Content Steering
+            Assert.NotNull(masterPlaylist.ContentSteering);
+            Assert.Equal("https://example.com/steering", masterPlaylist.ContentSteering.ServerUri);
+            Assert.Equal("CDN-A", masterPlaylist.ContentSteering.PathwayId);
+
+            // Assertions for Defines
+            Assert.Equal(2, masterPlaylist.Defines.Count);
+            Assert.Equal("VAR1", masterPlaylist.Defines[0].Name);
+            Assert.Equal("VAL1", masterPlaylist.Defines[0].Value);
+            Assert.Equal("VAR2", masterPlaylist.Defines[1].Import);
+
+            // Assertions for Media new attributes
+            Assert.Single(masterPlaylist.Medias);
+            var media = masterPlaylist.Medias[0];
+            Assert.Equal("Audio-37262", media.StableRenditionId);
+            Assert.Equal(24, media.BitDepth);
+            Assert.Equal(48000, media.SampleRate);
+
+            // Assertions for StreamInf new attributes
+            Assert.Single(masterPlaylist.Streams);
+            var stream = masterPlaylist.Streams[0];
+            Assert.Equal(9.5m, stream.Score);
+            Assert.Equal("dvh1.08.07/db4h", stream.SupplementalCodecs);
+            Assert.Equal("com.example:HW", stream.AllowedCpc);
+            Assert.Equal("Video-128", stream.StableVariantId);
+            Assert.Equal("CDN-A", stream.PathwayId);
+            Assert.Equal("CH-STEREO,CH-MONO", stream.ReqVideoLayout);
+
+            // Round-trip test
+            var serialized = masterPlaylist.ToString();
+            var roundTrip = MasterPlaylist.LoadFromText(serialized);
+
+            Assert.Equal(masterPlaylist.HlsVersion, roundTrip.HlsVersion);
+            Assert.Equal(masterPlaylist.ContentSteering.ServerUri, roundTrip.ContentSteering.ServerUri);
+            Assert.Equal(masterPlaylist.ContentSteering.PathwayId, roundTrip.ContentSteering.PathwayId);
+            Assert.Equal(masterPlaylist.Defines.Count, roundTrip.Defines.Count);
+            Assert.Equal(masterPlaylist.Medias[0].StableRenditionId, roundTrip.Medias[0].StableRenditionId);
+            Assert.Equal(masterPlaylist.Streams[0].Score, roundTrip.Streams[0].Score);
+            Assert.Equal(masterPlaylist.Streams[0].StableVariantId, roundTrip.Streams[0].StableVariantId);
+        }
+
+        [Fact]
+        public void TestMediaPlaylistWithNewTagsAndAttributes()
+        {
+            var manifestText = @"#EXTM3U
+#EXT-X-VERSION:13
+#EXT-X-DEFINE:NAME=""VAR_MEDIA"",VALUE=""VAL_MEDIA""
+#EXT-X-SERVER-CONTROL:CAN-SKIP-UNTIL=36.0,CAN-SKIP-DATERANGES=YES,HOLD-BACK=18.0,PART-HOLD-BACK=3.0,CAN-BLOCK-RELOAD=YES
+#EXT-X-PART-INF:PART-TARGET=1.0
+#EXT-X-TARGETDURATION:6
+#EXT-X-MEDIA-SEQUENCE:10
+#EXT-X-SKIP:SKIPPED-SEGMENTS=3,RECENTLY-REMOVED-DATERANGES=""range-1	range-2""
+
+#EXT-X-GAP
+#EXT-X-BITRATE:1200
+#EXT-X-PART:DURATION=1.0,INDEPENDENT=YES,URI=""part1.mp4""
+#EXT-X-PART:DURATION=1.0,GAP=YES,URI=""part2.mp4""
+#EXTINF:2.0,
+segment13.ts
+
+#EXT-X-PRELOAD-HINT:TYPE=PART,URI=""part3.mp4"",BYTERANGE-START=100,BYTERANGE-LENGTH=200
+#EXT-X-RENDITION-REPORT:URI=""/1M/LL-HLS.m3u8"",LAST-MSN=274,LAST-PART=1";
+
+            var mediaPlaylist = MediaPlaylist.LoadFromText(manifestText);
+
+            // Assertions for HlsVersion & Defines
+            Assert.Equal(13, mediaPlaylist.HlsVersion);
+            Assert.Single(mediaPlaylist.Defines);
+            Assert.Equal("VAR_MEDIA", mediaPlaylist.Defines[0].Name);
+            Assert.Equal("VAL_MEDIA", mediaPlaylist.Defines[0].Value);
+
+            // Assertions for ServerControl
+            Assert.NotNull(mediaPlaylist.ServerControl);
+            Assert.Equal(36.0m, mediaPlaylist.ServerControl.CanSkipUntil);
+            Assert.True(mediaPlaylist.ServerControl.CanSkipDateRanges);
+            Assert.Equal(18.0m, mediaPlaylist.ServerControl.HoldBack);
+            Assert.Equal(3.0m, mediaPlaylist.ServerControl.PartHoldBack);
+            Assert.True(mediaPlaylist.ServerControl.CanBlockReload);
+
+            // Assertions for PartInf
+            Assert.NotNull(mediaPlaylist.PartInf);
+            Assert.Equal(1.0m, mediaPlaylist.PartInf.PartTarget);
+
+            // Assertions for Skip
+            Assert.NotNull(mediaPlaylist.Skip);
+            Assert.Equal(3, mediaPlaylist.Skip.SkippedSegments);
+            Assert.Equal("range-1\trange-2", mediaPlaylist.Skip.RecentlyRemovedDateRanges);
+
+            // Assertions for Segment with new tags (Gap, Bitrate, Parts)
+            Assert.Single(mediaPlaylist.MediaSegments);
+            Assert.Single(mediaPlaylist.MediaSegments[0].Segments);
+            var segment = mediaPlaylist.MediaSegments[0].Segments[0];
+            Assert.True(segment.Gap);
+            Assert.Equal(1200, segment.Bitrate);
+            Assert.Equal(2, segment.Parts.Count);
+
+            var part1 = segment.Parts[0];
+            Assert.Equal(1.0m, part1.Duration);
+            Assert.True(part1.Independent);
+            Assert.Equal("part1.mp4", part1.Uri);
+
+            var part2 = segment.Parts[1];
+            Assert.Equal(1.0m, part2.Duration);
+            Assert.True(part2.Gap);
+            Assert.Equal("part2.mp4", part2.Uri);
+
+            // Assertions for PreloadHints & RenditionReports
+            Assert.Single(mediaPlaylist.PreloadHints);
+            var hint = mediaPlaylist.PreloadHints[0];
+            Assert.Equal("PART", hint.Type);
+            Assert.Equal("part3.mp4", hint.Uri);
+            Assert.Equal(100, hint.ByteRangeStart);
+            Assert.Equal(200, hint.ByteRangeLength);
+
+            Assert.Single(mediaPlaylist.RenditionReports);
+            var report = mediaPlaylist.RenditionReports[0];
+            Assert.Equal("/1M/LL-HLS.m3u8", report.Uri);
+            Assert.Equal(274, report.LastMsn);
+            Assert.Equal(1, report.LastPart);
+
+            // Round-trip test
+            var serialized = mediaPlaylist.ToString();
+            var roundTrip = MediaPlaylist.LoadFromText(serialized);
+
+            Assert.Equal(mediaPlaylist.HlsVersion, roundTrip.HlsVersion);
+            Assert.Equal(mediaPlaylist.Defines[0].Name, roundTrip.Defines[0].Name);
+            Assert.Equal(mediaPlaylist.ServerControl.CanSkipUntil, roundTrip.ServerControl.CanSkipUntil);
+            Assert.Equal(mediaPlaylist.PartInf.PartTarget, roundTrip.PartInf.PartTarget);
+            Assert.Equal(mediaPlaylist.Skip.SkippedSegments, roundTrip.Skip.SkippedSegments);
+            Assert.Equal(mediaPlaylist.MediaSegments[0].Segments[0].Gap, roundTrip.MediaSegments[0].Segments[0].Gap);
+            Assert.Equal(mediaPlaylist.MediaSegments[0].Segments[0].Bitrate, roundTrip.MediaSegments[0].Segments[0].Bitrate);
+            Assert.Equal(mediaPlaylist.MediaSegments[0].Segments[0].Parts.Count, roundTrip.MediaSegments[0].Segments[0].Parts.Count);
+            Assert.Equal(mediaPlaylist.PreloadHints[0].Type, roundTrip.PreloadHints[0].Type);
+            Assert.Equal(mediaPlaylist.RenditionReports[0].Uri, roundTrip.RenditionReports[0].Uri);
+        }
+    }
+}

--- a/tests/M3U8Parser.Tests/NewTagsAndAttributesTests.cs
+++ b/tests/M3U8Parser.Tests/NewTagsAndAttributesTests.cs
@@ -165,5 +165,82 @@ segment13.ts
             Assert.Equal(mediaPlaylist.PreloadHints[0].Type, roundTrip.PreloadHints[0].Type);
             Assert.Equal(mediaPlaylist.RenditionReports[0].Uri, roundTrip.RenditionReports[0].Uri);
         }
+
+        [Fact]
+        public void TestDateRangeAndHlsInterstitials()
+        {
+            var manifestText = @"#EXTM3U
+#EXT-X-VERSION:13
+#EXT-X-TARGETDURATION:6
+#EXT-X-DATERANGE:ID=""ad1"",CLASS=""com.apple.hls.interstitial"",START-DATE=""2020-01-02T21:55:44.000Z"",CUE=""PRE,POST"",DURATION=15.0,PLANNED-DURATION=15.0,END-ON-NEXT=YES,X-ASSET-URI=""http://example.com/ad1.m3u8"",X-ASSET-LIST=""http://example.com/adv.json"",X-RESUME-OFFSET=0,X-PLAYOUT-LIMIT=15.0,X-SNAP=""OUT,IN"",X-RESTRICT=""SKIP,JUMP"",X-CONTENT-MAY-VARY=""YES"",X-TIMELINE-OCCUPIES=""POINT"",X-TIMELINE-STYLE=""HIGHLIGHT"",X-SKIP-CONTROL-OFFSET=2,X-SKIP-CONTROL-DURATION=5,X-SKIP-CONTROL-LABEL-ID=""Exit-Label"",X-URI=""http://preload.com"",X-TARGET-ID=""target-1"",X-TARGET-CLASS=""class-1""
+
+#EXTINF:6,
+main1.ts";
+
+            var mediaPlaylist = MediaPlaylist.LoadFromText(manifestText);
+
+            // Assertions for DateRanges
+            Assert.Single(mediaPlaylist.DateRanges);
+            var dateRange = mediaPlaylist.DateRanges[0];
+
+            Assert.Equal("ad1", dateRange.Id);
+            Assert.Equal("com.apple.hls.interstitial", dateRange.Class);
+            Assert.Equal("2020-01-02T21:55:44.000Z", dateRange.StartDate);
+            Assert.Equal("PRE,POST", dateRange.Cue);
+            Assert.Equal(15.0m, dateRange.Duration);
+            Assert.Equal(15.0m, dateRange.PlannedDuration);
+            Assert.Equal("YES", dateRange.EndOnNext);
+
+            // Assertions for Interstitials
+            Assert.Equal("http://example.com/ad1.m3u8", dateRange.XAssetUri);
+            Assert.Equal("http://example.com/adv.json", dateRange.XAssetList);
+            Assert.Equal(0m, dateRange.XResumeOffset);
+            Assert.Equal(15.0m, dateRange.XPlayoutLimit);
+            Assert.Equal("OUT,IN", dateRange.XSnap);
+            Assert.Equal("SKIP,JUMP", dateRange.XRestrict);
+            Assert.Equal("YES", dateRange.XContentMayVary);
+            Assert.Equal("POINT", dateRange.XTimelineOccupies);
+            Assert.Equal("HIGHLIGHT", dateRange.XTimelineStyle);
+
+            // Assertions for Skip control
+            Assert.Equal(2, dateRange.XSkipControlOffset);
+            Assert.Equal(5, dateRange.XSkipControlDuration);
+            Assert.Equal("Exit-Label", dateRange.XSkipControlLabelId);
+
+            // Assertions for Preloading
+            Assert.Equal("http://preload.com", dateRange.XUri);
+            Assert.Equal("target-1", dateRange.XTargetId);
+            Assert.Equal("class-1", dateRange.XTargetClass);
+
+            // Round-trip test
+            var serialized = mediaPlaylist.ToString();
+            var roundTrip = MediaPlaylist.LoadFromText(serialized);
+
+            Assert.Single(roundTrip.DateRanges);
+            var roundTripDateRange = roundTrip.DateRanges[0];
+
+            Assert.Equal(dateRange.Id, roundTripDateRange.Id);
+            Assert.Equal(dateRange.Class, roundTripDateRange.Class);
+            Assert.Equal(dateRange.StartDate, roundTripDateRange.StartDate);
+            Assert.Equal(dateRange.Cue, roundTripDateRange.Cue);
+            Assert.Equal(dateRange.Duration, roundTripDateRange.Duration);
+            Assert.Equal(dateRange.PlannedDuration, roundTripDateRange.PlannedDuration);
+            Assert.Equal(dateRange.EndOnNext, roundTripDateRange.EndOnNext);
+            Assert.Equal(dateRange.XAssetUri, roundTripDateRange.XAssetUri);
+            Assert.Equal(dateRange.XAssetList, roundTripDateRange.XAssetList);
+            Assert.Equal(dateRange.XResumeOffset, roundTripDateRange.XResumeOffset);
+            Assert.Equal(dateRange.XPlayoutLimit, roundTripDateRange.XPlayoutLimit);
+            Assert.Equal(dateRange.XSnap, roundTripDateRange.XSnap);
+            Assert.Equal(dateRange.XRestrict, roundTripDateRange.XRestrict);
+            Assert.Equal(dateRange.XContentMayVary, roundTripDateRange.XContentMayVary);
+            Assert.Equal(dateRange.XTimelineOccupies, roundTripDateRange.XTimelineOccupies);
+            Assert.Equal(dateRange.XTimelineStyle, roundTripDateRange.XTimelineStyle);
+            Assert.Equal(dateRange.XSkipControlOffset, roundTripDateRange.XSkipControlOffset);
+            Assert.Equal(dateRange.XSkipControlDuration, roundTripDateRange.XSkipControlDuration);
+            Assert.Equal(dateRange.XSkipControlLabelId, roundTripDateRange.XSkipControlLabelId);
+            Assert.Equal(dateRange.XUri, roundTripDateRange.XUri);
+            Assert.Equal(dateRange.XTargetId, roundTripDateRange.XTargetId);
+            Assert.Equal(dateRange.XTargetClass, roundTripDateRange.XTargetClass);
+        }
     }
 }


### PR DESCRIPTION
This change implements the 10 new tags (#EXT-X-GAP, #EXT-X-BITRATE, #EXT-X-SERVER-CONTROL, #EXT-X-SKIP, #EXT-X-PART-INF, #EXT-X-PART, #EXT-X-PRELOAD-HINT, #EXT-X-RENDITION-REPORT, #EXT-X-CONTENT-STEERING, #EXT-X-DEFINE) introduced in draft-pantos-hls-rfc8216bis-22, and supports the new attributes on existing tags while keeping the library's design principle of no data validation.

---
*PR created automatically by Jules for task [7742775302556053541](https://jules.google.com/task/7742775302556053541) started by @xavierlaffargue*